### PR TITLE
長過ぎる投稿はサイドバーで省略して表示

### DIFF
--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -13,7 +13,7 @@
         .SidebarGroup__group-content
           - if join_group.group.messages.length != 0
             - if join_group.group.messages.last.body != ""
-              = join_group.group.messages.last.body
+              = join_group.group.messages.last.body.truncate(20)
             - else
               画像が投稿されました。
           - else


### PR DESCRIPTION
# WHAT
長過ぎる投稿が行われたグループでは、サイドバーの最新の投稿欄での表示を省略する

# WHY
レイアウト崩れを防ぐため